### PR TITLE
Fix Rails app background image asset paths

### DIFF
--- a/docker/ruby/app/assets/stylesheets/main.css.scss
+++ b/docker/ruby/app/assets/stylesheets/main.css.scss
@@ -18,7 +18,7 @@ body {
   line-height: 24px;
   color: $text;
   text-align: center;
-  background-image: url(pattern-tl.svg), url(pattern-br.svg);
+  background-image: url(asset-path('pattern-tl.svg')), url(asset-path('pattern-br.svg'));
   background-position: top left, bottom right;
   background-repeat: no-repeat;
   background-color: $background;


### PR DESCRIPTION
The background images don't show up, since the current paths are invalid.