### PR TITLE
docker/ruby: Add GEM_PATH and PATH for easier access to rails tools

### DIFF
--- a/docker/ruby/waypoint.hcl
+++ b/docker/ruby/waypoint.hcl
@@ -11,6 +11,11 @@ app "example-ruby" {
   }
 
   deploy { 
-    use "docker" {}
+    use "docker" {
+      static_environment = {
+        GEM_PATH = "/layers/heroku_ruby/gems/vendor/bundle/ruby/2.6.0"
+        PATH = "bin:/layers/heroku_ruby/gems/vendor/bundle/ruby/2.6.0/bin:/usr/local/bin:/usr/bin:/bin"
+      }
+    }
   }
 }


### PR DESCRIPTION
Adding these paths means you can simply run `bundle`, or `rails`
commands inside `app` when you first `waypoint exec` into the project.