### PR TITLE
Adds an example of static configuration as used on a Learn tutorial

### DIFF
--- a/learn/static-application-configuration/README.md
+++ b/learn/static-application-configuration/README.md
@@ -1,0 +1,11 @@
+# Static Waypoint Configuration Demo
+
+Follow along at [HashiCorp Learn](https://learn.hashicorp.com/tutorials/waypoint/static-application-configuration).
+
+| Title    | Description                                                                                        |
+| -------- | -------------------------------------------------------------------------------------------------- |
+| Pack     | Cloud Native Buildpack                                                                             |
+| Cloud    | Local                                                                                              |
+| Language | Go                                                                                                 |
+| Docs     | [Docker](https://www.waypointproject.io/plugins/docker)                                            |
+| Tutorial | [HashiCorp Learn](https://learn.hashicorp.com/tutorials/waypoint/static-application-configuration) |

--- a/learn/static-application-configuration/go.mod
+++ b/learn/static-application-configuration/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/waypoint-examples/learn/static-application-configuration
+
+go 1.15

--- a/learn/static-application-configuration/main.go
+++ b/learn/static-application-configuration/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	http.HandleFunc("/", saleViewHandler)
+
+	fmt.Printf("Starting server at: http://localhost:3000\n")
+	if err := http.ListenAndServe(":3000", nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func saleViewHandler(w http.ResponseWriter, r *http.Request) {
+	salePercent := os.Getenv("SALE_PERCENT")
+	saleEndsOn := os.Getenv("SALE_ENDS_ON")
+	fmt.Fprintf(w, `
+	<style>body { font-size: 3em; }</style>
+	<h1>Today&#8217;s Sale</h1>
+	<div>Save %s!</div>
+	<div>Until %s</div>
+	`,
+		salePercent,
+		saleEndsOn)
+}

--- a/learn/static-application-configuration/waypoint.hcl
+++ b/learn/static-application-configuration/waypoint.hcl
@@ -1,0 +1,22 @@
+project = "example-go"
+
+app "example-go" {
+  labels = {
+    "service" = "example-go",
+    "env"     = "dev"
+  }
+
+  config {
+    env = {
+       SALE_PERCENT = "50%"
+    }
+  }
+
+  build {
+    use "pack" {}
+  }
+
+  deploy {
+    use "docker" {}
+  }
+}


### PR DESCRIPTION
This is the first in a series of tutorials about using static and dynamic configuration with Waypoint.

The code uses Go but other examples may use other languages. It is in a `learn` subdirectory so that all code examples will be in this repo, but it won't conflict with other focused demo code in other platform-specific directories.