### PR TITLE
Bump mimemagic to 0.3.10 for docker/ruby example

### DIFF
--- a/docker/ruby/Gemfile.lock
+++ b/docker/ruby/Gemfile.lock
@@ -79,7 +79,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)


### PR DESCRIPTION
The previous version specified in Gemfile.lock (0.3.5) has been yanked, causing the build to fail on `waypoint up`.