### PR TITLE
Add docker plugin `extra_ports` usage example

### DIFF
--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -13,4 +13,4 @@ ADD /app/ /app/
 
 EXPOSE 8080
 
-CMD ["gunicorn", "-b", "0.0.0.0:8080", "wsgi", "-k", "gevent"]
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "-b", "0.0.0.0:8081","wsgi", "-k", "gevent"]

--- a/docker/python/README.md
+++ b/docker/python/README.md
@@ -2,5 +2,6 @@
 
 1. Run `waypoint init` in this example directory with `waypoint.hcl`.
 1. Run `waypoint up` to build and deploy the application.
+1. Run `docker ps` to view the locally running application on the two published ports
 
 For more information on Flask, see [https://palletsprojects.com/p/flask/](https://palletsprojects.com/p/flask/).

--- a/docker/python/waypoint.hcl
+++ b/docker/python/waypoint.hcl
@@ -13,6 +13,8 @@ app "example-python" {
   deploy {
     use "docker" {
       service_port = 8080
+
+      extra_ports = [8081]
     }
   }
 }


### PR DESCRIPTION
- Following the PR to add `extra_ports` parameter to docker plugin,
  this change adds an example of how `extra_ports` could be used.
  This is a contrived example, but demonstrates the functionality.