### PR TITLE
Add small EC2 example

### DIFF
--- a/aws/ec2/README.md
+++ b/aws/ec2/README.md
@@ -1,0 +1,15 @@
+# Waypoint AWS-EC2 Example
+
+|Title|Description|
+|---|---|
+|Pack|N/A|
+|Cloud|AWS|
+|Language|N/A|
+|Docs|[AWS-EC2](https://www.waypointproject.io/plugins/aws-ec2)|
+|Tutorial|N/A|
+
+This example demonstrates the AWS EC2 `deploy` plugin. This uses a public AMI
+for [NGINX][nginx] in `us-west` region as a simple example.
+
+
+[nginx]:https://bitnami.com/stack/nginx/cloud/aws/amis

--- a/aws/ec2/waypoint.hcl
+++ b/aws/ec2/waypoint.hcl
@@ -1,0 +1,33 @@
+project = "example-nginx-ami"
+
+app "nginx-example" {
+  labels = {
+    "service" = "nginx-example"
+    "env"     = "dev"
+  }
+
+  build {
+    use "aws-ami" {
+      filters = {
+        // See https://bitnami.com/stack/nginx/cloud/aws/amis
+        "image-id" = ["ami-0562fde33e9671bf4"]
+      }
+
+      region = "us-west-2"
+    }
+  }
+
+  deploy {
+    use "aws-ec2" {
+      region        = "us-west-2"
+      instance_type = "t3a.nano"
+      service_port  = 80
+    }
+  }
+
+  release {
+    use "aws-alb" {
+      port = 80
+    }
+  }
+}


### PR DESCRIPTION
Adds a small example using AWS EC2 with a [NGINX][nginx] AMI, released with the ALB releaser


[nginx]: https://bitnami.com/stack/nginx/cloud/aws/amis