### PR TITLE
revert vpc access inclusion for gcp plugin

### DIFF
--- a/gcp/google-cloud-run/nodejs/waypoint.hcl
+++ b/gcp/google-cloud-run/nodejs/waypoint.hcl
@@ -38,11 +38,6 @@ app "example-nodejs" {
       auto_scaling {
         max = 2
       }
-      
-      vpc_access {
-        connector = "<my-connector-name>"
-        egress = "all"
-      }
     }
   }
 


### PR DESCRIPTION
The VPC access block is `optional`; this was an error in our docs that is being fixed momentarily.
Learn guide: https://github.com/hashicorp/learn/pull/3822
Docs update: https://github.com/hashicorp/waypoint/pull/2102/files