### PR TITLE
k8s: Use a load balancer for release

### DIFF
--- a/kubernetes/nodejs-local-registry/waypoint.hcl
+++ b/kubernetes/nodejs-local-registry/waypoint.hcl
@@ -25,6 +25,9 @@ app "example-nodejs" {
 
   release {
     use "kubernetes" {
+      // Sets up a load balancer to access released application
+      load_balancer = true
+      port          = 3000
     }
   }
 }

--- a/kubernetes/nodejs/waypoint.hcl
+++ b/kubernetes/nodejs/waypoint.hcl
@@ -25,6 +25,9 @@ app "example-nodejs" {
 
   release {
     use "kubernetes" {
+      // Sets up a load balancer to access released application
+      load_balancer = true
+      port          = 3000
     }
   }
 }


### PR DESCRIPTION
Prior to this commit, the releases for the Kubernetes examples would use
the default cluster internal IP for the service it sets up. This means
the release was not accessible outside of the k8s cluster. This commit
fixes that by opting for using a LoadBalancer type for the service
instead so that the release URL is available and accessible.