### PR TITLE
multiworkspace example

### DIFF
--- a/kubernetes/go-multiworkspace/Dockerfile
+++ b/kubernetes/go-multiworkspace/Dockerfile
@@ -1,0 +1,29 @@
+#--------------------------------------------------------------------
+# builder
+#--------------------------------------------------------------------
+
+FROM golang:1.17.2-alpine3.14 AS builder
+
+WORKDIR /app-src
+
+COPY go.mod ./
+COPY go.sum ./
+
+RUN go mod download
+
+COPY . ./
+
+RUN go build -o /tmp/go-multiworkspace 
+
+#--------------------------------------------------------------------
+# final image
+#--------------------------------------------------------------------
+
+FROM alpine:3.14
+
+# Config is expected to be delivered here at runtime
+RUN mkdir /opt/config
+
+COPY --from=builder /tmp/go-multiworkspace /go-multiworkspace
+
+CMD [ "/go-multiworkspace" ]

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -7,7 +7,7 @@
 | Language | Go                                                                                   |
 | Tutorial | coming soon                                                                          |
 
-This is a complex example showing how workspaces can be used to model dev and prod environments, where dev and prod have different namespaces, different config (sourced from vault), and different load balancers, with only the prod loadbanalcer public.
+This is a complex example showing how workspaces can be used to model dev and prod environments, where dev and prod have different namespaces, different config (sourced from vault), and different load balancers, with only the prod load balancer public.
 
 
 ## Prerequisites

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -26,7 +26,7 @@ This has been tested with an [HCP Vault](https://cloud.hashicorp.com/#vault) clu
 
 ### AWS setup
 
-This project uses the AWS ECR container registry, AWS loadbalancers, and has been tested on EKS. To support gitops workflows, Waypoint runners need push access to ECR - this can be accomplished by adding the AmazonEc2ContainerRegistryFullAccess policy to the eks node group role, but more granuar access is also possible.
+This project uses the AWS ECR container registry, AWS loadbalancers, and has been tested on EKS. To support gitops workflows, Waypoint runners need push access to ECR - this can be accomplished by adding the `AmazonEc2ContainerRegistryFullAccess` policy to the EKS node group role, but more granular access is also possible.
 
 
 ## Dev and Prod Environments

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -11,6 +11,9 @@ This is a complex example showing how workspaces can be used to model dev and pr
 
 
 ## Prerequisites
+### Kubernetes namespaces
+
+You should have namespaces in your k8s cluster named `dev` and `prod`. These names are used in the waypoint.hcl.
 
 ### Waypoint installation
 

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -36,7 +36,7 @@ In this example, the dev environment is represented by the "default" Waypoint wo
 To deploy to dev:
 
 ```shell-session
-$ Waypoint up
+$ waypoint up
 ```
 
 To interact with the prod environment, add the `-workspace=prod` flag to any Waypoint command. After verifying changes in dev,

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -43,6 +43,6 @@ To interact with the prod environment, add the `-workspace=prod` flag to any Way
 they can be deployed to prod with:
 
 ```shell-session
-$ Waypoint up -workspace=prod
+$ waypoint up -workspace=prod
 ```
 

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -40,7 +40,7 @@ $ waypoint up
 ```
 
 To interact with the prod environment, add the `-workspace=prod` flag to any Waypoint command. After verifying changes in dev,
-they can be deployed to prod with
+they can be deployed to prod with:
 
 ```shell-session
 $ Waypoint up -workspace=prod

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -1,0 +1,48 @@
+# Waypoint Multi-Workspace example (in go)
+
+| Title    | Description                                                                          |
+| -------- | ------------------------------------------------------------------------------------ |
+| Pack     | Docker                                                                               |
+| Cloud    | Kubernetes/AWS                                                                       |
+| Language | Go                                                                                   |
+| Tutorial | coming soon                                                                          |
+
+This is a complex example showing how workspaces can be used to model dev and prod environments, where dev and prod have different namespaces, different config (sourced from vault), and different load balancers, with only the prod loadbanalcer public.
+
+
+## Prerequisites
+
+### Waypoint installation
+
+Waypoint will need to be installed in such a way that it can access the dev and prod k8s namespaces. This is most easily accomplished by installing Waypoint with the [helm](https://www.Waypointproject.io/docs/kubernetes/helm-deploy)
+
+### Vault setup
+
+A vault cluster is required. It's api address must be reachable from pods in your dev and prod namespaces. The best way to set this up is by configuring the [vault kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes), and the Waypoint vault config sourcer using [kubernetes auth](https://www.Waypointproject.io/plugins/vault#kubernetes_role).
+
+This also presumes that dev and prod exist in vault under a KV secrets engine named `config`, with the path `gomultiapp/{dev,prod}/config.yml`
+
+This has been tested with an [HCP Vault](https://cloud.hashicorp.com/#vault) cluster peered to the AWS VPC that contiains the EKS cluster.
+
+### AWS setup
+
+This project uses the AWS ECR container registry, AWS loadbalancers, and has been tested on EKS. To support gitops workflows, Waypoint runners need push access to ECR - this can be accomplished by adding the AmazonEc2ContainerRegistryFullAccess policy to the eks node group role, but more granuar access is also possible.
+
+
+## Dev and Prod Environments
+
+In this example, the dev environment is represented by the "default" Waypoint workspace, and prod by the "prod" workspace.
+
+Deploying in dev is as easy as 
+
+```shell-session
+$ Waypoint up
+```
+
+To interact with the prod environment, add the `-workspace=prod` flag to any Waypoint command. After verifying changes in dev,
+they can be deployed to prod with
+
+```shell-session
+$ Waypoint up -workspace=prod
+```
+

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -18,7 +18,7 @@ Waypoint will need to be installed in such a way that it can access the dev and 
 
 ### Vault setup
 
-A vault cluster is required. Its api address must be reachable from pods in your dev and prod namespaces. The best way to set this up is by configuring the [vault kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes), and the Waypoint vault config sourcer using [kubernetes auth](https://www.Waypointproject.io/plugins/vault#kubernetes_role).
+A Vault cluster is required. Its api address must be reachable from pods in your dev and prod namespaces. The best way to set this up is by configuring the [Vault Kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes), and the Waypoint Vault config sourcer using [Kubernetes auth](https://www.Waypointproject.io/plugins/vault#kubernetes_role).
 
 This also presumes that dev and prod exist in vault under a KV secrets engine named `config`, with the path `gomultiapp/{dev,prod}/config.yml`
 

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -18,7 +18,7 @@ Waypoint will need to be installed in such a way that it can access the dev and 
 
 ### Vault setup
 
-A vault cluster is required. It's api address must be reachable from pods in your dev and prod namespaces. The best way to set this up is by configuring the [vault kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes), and the Waypoint vault config sourcer using [kubernetes auth](https://www.Waypointproject.io/plugins/vault#kubernetes_role).
+A vault cluster is required. Its api address must be reachable from pods in your dev and prod namespaces. The best way to set this up is by configuring the [vault kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes), and the Waypoint vault config sourcer using [kubernetes auth](https://www.Waypointproject.io/plugins/vault#kubernetes_role).
 
 This also presumes that dev and prod exist in vault under a KV secrets engine named `config`, with the path `gomultiapp/{dev,prod}/config.yml`
 

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -33,7 +33,7 @@ This project uses the AWS ECR container registry, AWS loadbalancers, and has bee
 
 In this example, the dev environment is represented by the "default" Waypoint workspace, and prod by the "prod" workspace.
 
-Deploying in dev is as easy as 
+To deploy to dev:
 
 ```shell-session
 $ Waypoint up

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -20,7 +20,7 @@ Waypoint will need to be installed in such a way that it can access the dev and 
 
 A Vault cluster is required. Its api address must be reachable from pods in your dev and prod namespaces. The best way to set this up is by configuring the [Vault Kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes), and the Waypoint Vault config sourcer using [Kubernetes auth](https://www.Waypointproject.io/plugins/vault#kubernetes_role).
 
-This also presumes that dev and prod exist in vault under a KV secrets engine named `config`, with the path `gomultiapp/{dev,prod}/config.yml`
+This also presumes that dev and prod exist in Vault under a KV secrets engine named `config`, with the path `gomultiapp/{dev,prod}/config.yml`
 
 This has been tested with an [HCP Vault](https://cloud.hashicorp.com/#vault) cluster peered to the AWS VPC that contains the EKS cluster.
 

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -22,7 +22,7 @@ A vault cluster is required. Its api address must be reachable from pods in your
 
 This also presumes that dev and prod exist in vault under a KV secrets engine named `config`, with the path `gomultiapp/{dev,prod}/config.yml`
 
-This has been tested with an [HCP Vault](https://cloud.hashicorp.com/#vault) cluster peered to the AWS VPC that contiains the EKS cluster.
+This has been tested with an [HCP Vault](https://cloud.hashicorp.com/#vault) cluster peered to the AWS VPC that contains the EKS cluster.
 
 ### AWS setup
 

--- a/kubernetes/go-multiworkspace/README.md
+++ b/kubernetes/go-multiworkspace/README.md
@@ -14,7 +14,7 @@ This is a complex example showing how workspaces can be used to model dev and pr
 
 ### Waypoint installation
 
-Waypoint will need to be installed in such a way that it can access the dev and prod k8s namespaces. This is most easily accomplished by installing Waypoint with the [helm](https://www.Waypointproject.io/docs/kubernetes/helm-deploy)
+Waypoint will need to be installed in such a way that it can access the dev and prod k8s namespaces. This is most easily accomplished by installing Waypoint with the [helm chart](https://www.Waypointproject.io/docs/kubernetes/helm-deploy).
 
 ### Vault setup
 

--- a/kubernetes/go-multiworkspace/config.yml
+++ b/kubernetes/go-multiworkspace/config.yml
@@ -1,0 +1,2 @@
+hello_message: "hello from local"
+port: 8080

--- a/kubernetes/go-multiworkspace/go.mod
+++ b/kubernetes/go-multiworkspace/go.mod
@@ -1,0 +1,5 @@
+module go-multiworkspace
+
+go 1.16
+
+require gopkg.in/yaml.v2 v2.4.0

--- a/kubernetes/go-multiworkspace/go.sum
+++ b/kubernetes/go-multiworkspace/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/kubernetes/go-multiworkspace/main.go
+++ b/kubernetes/go-multiworkspace/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"gopkg.in/yaml.v2"
+)
+
+const CONFIG_PATH_KEY = "CONFIG_PATH"
+
+
+type config struct {
+	HelloMessage string `yaml:"hello_message"`
+	Port int `yaml:"port"`
+}
+
+func loadConfig() (*config, error) {
+
+	configPath := os.Getenv(CONFIG_PATH_KEY)
+	if configPath == "" {
+		return nil, fmt.Errorf("%s not set", CONFIG_PATH_KEY)
+	}
+	configFile, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var c config
+	if err := yaml.Unmarshal(configFile, &c); err != nil {
+		return nil, fmt.Errorf("failed parsing config: %s", err)
+	}
+
+	return &c, nil
+}
+
+func main() {
+	cfg, err := loadConfig()
+	if err != nil {
+		panic(err)
+	}
+
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("healthy\n"))
+		return
+	})
+
+	http.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Hello request from Addr: %s, Host: %s", r.RemoteAddr, r.Host)
+		w.Write([]byte(fmt.Sprintf("Here is today's message: %q\n", cfg.HelloMessage)))
+		return
+	})
+
+	// Apply default port if necessary
+	var port int
+	if cfg.Port != 0 {
+		port = cfg.Port
+	} else {
+		port = 8080
+		log.Printf("Defaulting to port %d", port)
+	}
+
+	serveAddr := fmt.Sprintf(":%d", port)
+	log.Printf("Starting server at: %s\n", serveAddr)
+	if err := http.ListenAndServe(serveAddr, nil); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/kubernetes/go-multiworkspace/waypoint.hcl
+++ b/kubernetes/go-multiworkspace/waypoint.hcl
@@ -1,0 +1,87 @@
+project = "go-multiworkspace"
+
+app "backend" {
+
+  config {
+    env = {
+      "CONFIG_PATH" = "/opt/config/config.yml"
+    }
+
+    workspace "default" {
+      file = {
+        "/opt/config/config.yml" = configdynamic("vault", {
+          path = "config/data/go-multiworkspace/dev"
+          key  = "data/config.yml"
+        })
+      }
+    }
+
+    workspace "prod" {
+      file = {
+        "/opt/config/config.yml" = configdynamic("vault", {
+          path = "config/data/go-multiworkspace/prod"
+          key  = "data/config.yml"
+        })
+      }
+    }
+  }
+
+  build {
+    use "docker" {}
+    registry {
+      use "aws-ecr" {
+        region     = "us-east-2"
+        repository = "acmecorp"
+        tag        = gitrefpretty()
+      }
+    }
+  }
+
+  deploy {
+    use "kubernetes" {
+
+      # Use the dev kubernetes namespace with the dev workspace, and prod with prod.
+      # Error on any other workspace.
+      namespace = {
+        "default"  = "dev"
+        "prod" = "prod"
+      }[workspace.name]
+
+      probe_path = "/health"
+
+      service_account = "go-multiworkspace"
+      service_port = 8080
+    }
+  }
+
+  release {
+    use "kubernetes" {
+
+      # Use the dev kubernetes namespace with the dev workspace, and prod with prod.
+      # Error on any other workspace.
+      namespace = {
+        "default"  = "dev"
+        "prod" = "prod"
+      }[workspace.name]
+
+      load_balancer = true
+
+      annotations = {
+
+        # Assign an internal load balancer in dev, and external in prod
+        "service.beta.kubernetes.io/aws-load-balancer-internal" = {
+          "default"  = "true"
+          "prod" = "false"
+        }[workspace.name]
+
+        #        # Use the correct cert for the workspace
+        #        "service.beta.kubernetes.io/aws-load-balancer-ssl-cert" = {
+        #          "dev"  = "dev-cert-arn"
+        #          "prod" = "prod-cert-arn"
+        #        }[workspace.name] 
+
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
This is a complex example showing how workspaces can be used to model dev and prod environments, where dev and prod have different namespaces, different config (sourced from vault), and different load balancers, with only the prod loadbanalcer public.

Some of the infra setup to feed this is non-trivial - especially the vault integration. I think a tutorial showing how to get this app off the ground from end-to-end could be valuable.

More context (including demo video) for internal folks here: https://hashicorp.slack.com/archives/C013QT1KG9W/p1635547522239600