### PR TITLE
Nomad: Add Nomad Canary releaser to jobspec plugin

### DIFF
--- a/nomad/nodejs-jobspec/app.nomad.tpl
+++ b/nomad/nodejs-jobspec/app.nomad.tpl
@@ -1,14 +1,20 @@
 job "web" {
   datacenters = ["dc1"]
   group "app" {
+    update {
+      max_parallel = 1
+      canary       = 1
+      auto_revert  = true
+      auto_promote = false
+      health_check = "task_states"
+    }
+
     task "app" {
       driver = "docker"
       config {
         image = "${artifact.image}:${artifact.tag}"
-
-        // For local Nomad, you prob don't need this on a real deploy
-        network_mode = "host"
       }
+
       env {
         %{ for k,v in entrypoint.env ~}
         ${k} = "${v}"

--- a/nomad/nodejs-jobspec/waypoint.hcl
+++ b/nomad/nodejs-jobspec/waypoint.hcl
@@ -19,4 +19,13 @@ app "example-nodejs" {
       jobspec = templatefile("${path.app}/app.nomad.tpl")
     }
   }
+
+  release {
+    use "nomad-jobspec-canary" {
+      groups = [
+        "app"
+      ]
+      fail_deployment = false
+    }
+  }
 }


### PR DESCRIPTION
This commit updates the nomad jobspec plugin example to also use the
recently released Nomad Canary plugin for releases.