### PR TITLE
Go-Gitops: Use Waypoints Vault Dynamic Config Sourcer plugin for values

### DIFF
--- a/kubernetes/go-gitops/README.md
+++ b/kubernetes/go-gitops/README.md
@@ -14,3 +14,8 @@ This example assumes you will be deploying the application onto Kubernetes.
 It also uses a remote container registry jFrog. You'll need
 to change the image value to point at your own registry. And be sure to setup
 your local Kubernetes cluster to have credentials to pull the image.
+
+This example also allows users to pull registry information out of Vault. For
+default values of a registry username and password, Waypoint can use its
+dynamic config sourcer plugin to obtain these values rather than requiring that
+they be set on the CLI or UI or checked into Git in a `waypoint.hcl`.

--- a/kubernetes/go-gitops/README.md
+++ b/kubernetes/go-gitops/README.md
@@ -19,3 +19,20 @@ This example also allows users to pull registry information out of Vault. For
 default values of a registry username and password, Waypoint can use its
 dynamic config sourcer plugin to obtain these values rather than requiring that
 they be set on the CLI or UI or checked into Git in a `waypoint.hcl`.
+
+If you wish to use Vault for configuring defaults, you may run the following
+vault command to set up the secrets inside your Vault server:
+
+```
+vault kv put secret/registry registry_username=USERNAME registry_password=PASSWORD
+```
+
+We'll need to update Waypoint to ensure the Vault dynamic config sourcer plugin
+has the proper hostname and root token to access Vault:
+
+```
+waypoint config source-set -type=vault -config=addr=<Vault address> -config=token=<Vault token>
+```
+
+Then, assuming your pod in Kubernetes can access Vault, when Waypoint goes to
+evaluate your input variables, it will use Vault to fill out these values.

--- a/kubernetes/go-gitops/waypoint.hcl
+++ b/kubernetes/go-gitops/waypoint.hcl
@@ -12,17 +12,23 @@ variable "tag" {
   description = "Image tag for the image"
 }
 
-// set your registry username through the UI or on the CLI!
 variable "registry_username" {
-  default     = ""
+  default = dynamic("vault", {
+    path = "config/data/secret/registry"
+    key  = "data/registry_username"
+  })
   type        = string
+  sensitive   = true
   description = "username for container registry"
 }
 
-// set your registry password through the UI or on the CLI!
 variable "registry_password" {
-  default     = ""
+  default = dynamic("vault", {
+    path = "config/data/secret/registry"
+    key  = "data/registry_password"
+  })
   type        = string
+  sensitive   = true
   description = "password for registry" // DO NOT COMMIT YOUR PASSWORD TO GIT
 }
 


### PR DESCRIPTION
This commit uses the dynamic config sourcer Vault plugin in Waypoint to
optionally obtain default values for sensitive input vars
registry_username and registry_password. It also marks them as
sensitive.