### PR TITLE
Add AWS ECR pull example.

### DIFF
--- a/aws/lambda/nodejs/waypoint.hcl
+++ b/aws/lambda/nodejs/waypoint.hcl
@@ -1,0 +1,34 @@
+project = "example-nodejs"
+
+app "example-nodejs" {
+  build {
+   use "aws-ecr-pull" {
+     region     = var.region
+     repository = "example-nodejs"
+     tag        = var.tag
+   }
+  }
+
+  deploy {
+    use "aws-lambda" {
+      region = var.region
+      memory = 512
+    }
+  }
+
+  release {
+    use "lambda-function-url" {
+
+    }
+  }
+}
+
+variable "region" {
+  type = string
+  default = "us-east-1"
+}
+
+variable "tag" {
+  type = string
+  default = "1"
+}


### PR DESCRIPTION
This PR adds an example for the new AWS ECR pull plugin. There is no code alongside the `waypoint.hcl` file because the nature of this builder is that a pre-existing image is pulled from an AWS ECR repository. The image in this example file is `example-nodejs`, an app that is built in other locations in this repo.