### PR TITLE
Add `prune_whitelist` to k8s/nodejs-apply example

### DIFF
--- a/kubernetes/nodejs-apply/waypoint.hcl
+++ b/kubernetes/nodejs-apply/waypoint.hcl
@@ -29,6 +29,11 @@ app "apply-nodejs-web" {
       // This label determines what resources we own. Any that aren't present
       // in our folder that match this label will be deleted.
       prune_label = "app=myapp"
+
+      // This is a list of Kubernetes Objects that are allowed to be pruned.
+      // Specify them as group/version/kind (e.g: apps/v1/Deployment).
+      // See https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply --prune-allowlist
+      prune_whitelist = ["apps/v1/Deployment"]
     }
   }
 }


### PR DESCRIPTION
Without this, `waypoint up` fails as follows:

```
» Deploying apply-nodejs-web...
! /path/to/waypoint-examples/kubernetes/nodejs-apply/waypoint.hcl:24,28-28:
  Missing required argument; The argument "prune_whitelist" is required, but no
  definition was found.
```

Though the comments say an empty list implies the default objects, with `prune_whitelist = []` we get this:

```
» Releasing apply-nodejs-web...panic: must not call ListVal with empty slice

goroutine 64 [running]:
github.com/zclconf/go-cty/cty.ListVal({0x109402db8?, 0x14000c7acb0?, 0x0?})
	/path/to/go/pkg/mod/github.com/zclconf/go-cty@v1.8.4/cty/value_init.go:157 +0x468
github.com/hashicorp/waypoint/internal/pkg/ctystructure.toValueList({0x103aa9400?, 0x14001ae6120?, 0x14001a20608?}, {0x14000c7acb0?, 0x1?, 0x14?})
	/path/to/hashicorp/waypoint/internal/pkg/ctystructure/object.go:73 +0x32c
```

Ultimately, we should make this param optional (and rename it to `prune_allowlist`) but for now this fixes the example.