### PR TITLE
docker/go - use start command to avoid exit 82

### DIFF
--- a/docker/go-multiapp/waypoint.hcl
+++ b/docker/go-multiapp/waypoint.hcl
@@ -14,7 +14,9 @@ app "app-1" {
   }
 
   deploy {
-    use "docker" {}
+    use "docker" {
+      command = ["bin/go-multiapp"]
+    }
   }
 }
 
@@ -29,6 +31,8 @@ app "app-2" {
   }
 
   deploy {
-    use "docker" {}
+    use "docker" {
+      command = ["bin/go-multiapp"]
+    }
   }
 }

--- a/docker/go/waypoint.hcl
+++ b/docker/go/waypoint.hcl
@@ -14,6 +14,8 @@ app "example-go" {
   }
 
   deploy {
-    use "docker" {}
+    use "docker" {
+      command = ["bin/go"]
+    }
   }
 }


### PR DESCRIPTION
I was trying the go examples and although shown as healthy in the UI the actual docker container was not running. Looking into the docker container logs I found the following:

```
2023-04-13T08:19:17.551Z [INFO]  entrypoint: entrypoint starting: deployment_id="" instance_id=01GXWV53DF0WJEHAV28CZNF7PW args=["/cnb/lifecycle/launcher"]
2023-04-13T08:19:17.551Z [INFO]  entrypoint: entrypoint version: full_string=v0.11.0 version=v0.11.0 prerelease="" metadata="" revision=""
2023-04-13T08:19:17.552Z [DEBUG] entrypoint.child: waiting for stateChildReady to flip to true
2023-04-13T08:19:17.552Z [DEBUG] entrypoint.child: starting child command watch loop
2023-04-13T08:19:17.552Z [DEBUG] entrypoint.child: child command received
2023-04-13T08:19:17.552Z [INFO]  entrypoint.child: starting child process: args=["/cnb/lifecycle/launcher"] cmd=/cnb/lifecycle/launcher
ERROR: failed to launch: determine start command: when there is no default process a command is required
2023-04-13T08:19:17.554Z [WARN]  entrypoint.child: subprocess exited: args=["/cnb/lifecycle/launcher"] cmd=/cnb/lifecycle/launcher err="exit status 82"
2023-04-13T08:19:17.554Z [INFO]  entrypoint.child: child process exited on its own: err="exit status 82"
Error initializing Waypoint entrypoint: exit status 82
```

Although the buildpack created a `Procfile` it is not honoured by `/cnb/lifecycle/launcher` when invoked via docker cli. Comparing the image with the working `example-nodejs:latest` it seems that a different launcher is used (`launcher` instead of `web`):
```
$ docker inspect {example-go:latest,example-nodejs:latest} --format "{{ .Config.Entrypoint }}"
[/waypoint-entrypoint /cnb/lifecycle/launcher]
[/waypoint-entrypoint /cnb/process/web]
```
I added a specific `command` to the `docker` block to fix this issue as I did not want to temper around buildpack configurations.

Waypoint configuration:

```
waypoint version
CLI: v0.11.0 (e92d6fbe0)
Server: v0.11.0
```

```
$ docker inspect {waypoint-server,waypoint-static-runner} --format '{{ .Image }}'
sha256:683b339ffffe977efd50002c2b383c4c76d2da44e9850e034fee9dd470cd61c5
sha256:683b339ffffe977efd50002c2b383c4c76d2da44e9850e034fee9dd470cd61c5
```

[build.log](https://github.com/hashicorp/waypoint-examples/files/11219939/build.log)

