### PR TITLE
Update README.md

### DIFF
--- a/project-templates/ecs/basic/README.md
+++ b/project-templates/ecs/basic/README.md
@@ -53,7 +53,7 @@ Create the baseline infrastructure with the following steps in your CLI.
 2. Update the `main.tf` file with the `{{YOUR_TERRAFORM_ORGANIZATION_NAME}}` field and replace the value with your own Terraform Cloud organization name.
    <br>
    <br>
-3. Run `terraform init` and the `terraform apply -var=vpc_name=example-cluster` command in this directory.
+3. Run `terraform init` and the `terraform apply -var=cluster_name=example-cluster` command in this directory.
    <br>
    <br>
    <br>


### PR DESCRIPTION
Should this be `-var=cluster_name=example-cluster` instead? I got an error when using `vpd_name`:

```terraform
Preparing the remote plan...

╷
│ Error: Value for undeclared variable
│
│ A variable named "vpc_name" was assigned on the command line, but the root module does not declare a variable of
│ that name. To use this value, add a "variable" block to the configuration.
```