### PR TITLE
Use a data source to only get available azs

### DIFF
--- a/project-templates/ecs/basic/terraform-aws-example-network/main.tf
+++ b/project-templates/ecs/basic/terraform-aws-example-network/main.tf
@@ -17,6 +17,10 @@ provider "aws" {
   region = "us-west-1"
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.18.1"
@@ -24,7 +28,7 @@ module "vpc" {
   name = var.vpc_name
   cidr = "172.31.0.0/16"
 
-  azs             = ["us-west-1b", "us-west-1c"]
+  azs             = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
   private_subnets = ["172.31.0.0/20", "172.31.16.0/20"]
   public_subnets  = ["172.31.80.0/20", "172.31.96.0/20"]
 
@@ -50,11 +54,11 @@ resource "aws_security_group" "internal" {
 
   # Allow ingress from other internal microservice_infra
   ingress {
-    description      = "internal traffic"
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    self             = true
+    description = "internal traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = true
   }
 
   tags = var.tags


### PR DESCRIPTION
Use a data source to find the available AZs. Over a long enough period of time (days, weeks months?) the results here _could_ change, but it's unlikely to change over the course of this example setup