### PR TITLE
fix: Change the app name of nodejs-graphql to comply TargetGroup name length limit

### DIFF
--- a/aws/lambda/nodejs-graphql/waypoint.hcl
+++ b/aws/lambda/nodejs-graphql/waypoint.hcl
@@ -3,7 +3,7 @@
 
 project = "waypoint-apollo-lambda"
 
-app "waypoint-apollo-lambda-function" {
+app "waypoint-apollo-lambda-func" {
   build {
     use "docker" {
       buildkit = true


### PR DESCRIPTION
# Context

I cloned the `waypoint-examples` repo to test out various app deployments with Waypoint. I made no code change to any of the examples.

I correctly initialized waypoint and installed the `docker` platform with the necessary `-accept-tos` flag.

# Problem

When running `waypoint up`, I get the following error that stops the process:

```
 ! Creating TargetGroup for Lambda version
! ValidationError: Target group name 'waypoint-apollo-lambda-function-' cannot
  begin or end with '-'
  	status code: 400, request id: 8a3f2f36-eb22-43af-bca8-6fdc3418b666
```

I created an issue describing the error in more detail: https://github.com/hashicorp/waypoint-examples/issues/131

My investigations on the source code of Waypoint show that we set the service name (aka TargetGroup name) as the app name, concatenated with an id, using the `-` symbol, as shown here:

https://github.com/hashicorp/waypoint/blob/88abbbc33039d3ba82a49c5c759460c999c8370e/builtin/aws/lambda/platform.go#L547

Then on line 552, we only keep the first 32 characters because that's the limitation set by AWS for TargetGroup names.

That produced my issue because `waypoint-apollo-lambda-function-` is exactly 32 characters in length.

# Solution

- [x] Reduce the app name length

By changing the app name from `waypoint-apollo-lambda-function` to `waypoint-apollo-lambda-func`, I was able to create the TargetGroup `waypoint-apollo-lambda-func-01H7`, which is 32 characters in length.

This is a reasonable solution because we keep the reference to the lambda function in our app name (using the `func` keyword) and don't introduce code changes in Waypoint to be more explicit on what's happening.

--

Closes https://github.com/hashicorp/waypoint-examples/issues/131
